### PR TITLE
다음 테스트를 실행하기 전에 비동기 작업이 종료되지 않은 경우 강제로 종료하도록 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,6 @@ dependencies {
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.rest-assured:rest-assured'
-	testImplementation 'org.awaitility:awaitility:4.2.0'
 	testImplementation 'io.findify:s3mock_2.13:0.2.6'
 
 	// API Docs


### PR DESCRIPTION
## 📃 Description
- 비동기 작업이 완료될때까지 최대 3초 동안 대기한다.
- 만약 3초가 지나도 비동기 작업이 종료되지 않았다면 강제로 종료한다.
- 사용하지 않는 awaitility 의존성 제거